### PR TITLE
Updating _run_get_stderr() to not break on failed installs from pip()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     url='https://github.com/nbgallery/ipydeps',
     packages=['ipydeps'],
     package_data={'ipydeps': ['data/*.txt']},
-    install_requires=['pip', 'setuptools', 'pypki2>=0.10.1'],
+    install_requires=['pip', 'setuptools', 'pypki2>=0.10.1', 'tqdm'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Topic :: Utilities',


### PR DESCRIPTION
...and to return a dict of `{package : (returncode, err)}` pairs for `_log_before_after` output if exception is raised. 


Example:
```
Running pip to install bad_package_name_here, geopandas, other_broken_package_there

New packages installed: geopandas

Unable to install the following packages: bad_package_name_here, other_broken_package_there

Could not find a version that satisfies the requirement other_broken_package_there (from versions: )
No matching distribution found for other_broken_package_there

Could not find a version that satisfies the requirement bad_package_name_here (from versions: )
No matching distribution found for bad_package_name_here

Done
```

Also adding sample tqdm progress bar for showing install progress.


For issue 34: https://github.com/nbgallery/ipydeps/issues/34